### PR TITLE
manually cleave hugo summaries for october events

### DIFF
--- a/content/events/2024/1007-11-icrs_sh.md
+++ b/content/events/2024/1007-11-icrs_sh.md
@@ -6,6 +6,7 @@ end: 2024-10-11T17:00:00
 ---
 
 Welcome to a hybrid, on-/off-line Scavenger Hunt event, run in collaboration with RoboSoc (ICRS).
+<!--more-->
 
 We'll be intertwining the mechanical and physical prowess of RoboSoc with the digital and mental prowess of CyberSoc to have you engage in a test of wit (and patience) as you race to complete our trial of 6 challenges.
 

--- a/content/events/2024/1010-timing_attacks.md
+++ b/content/events/2024/1010-timing_attacks.md
@@ -7,6 +7,7 @@ location: "Beit: Meeting Room 3"
 ---
 
 Checking the time can be a powerful strategy to leak information from even the most secure systems.
+<!--more-->
 
 In this workshop, we'll help you design an attack on a simple password-checking system, and later we'll show you how to design a secure password-checking method.
 

--- a/content/events/2024/1015-beginner_ctf.md
+++ b/content/events/2024/1015-beginner_ctf.md
@@ -7,7 +7,7 @@ location: "TBA"
 ---
 
 In this session, you will be tackling some easy CTF challenges, with the help and guidance of our committee members.
-
+<!--more-->
 (and possibly more experienced Society Members).
 
 We'll show you the types of challenges you can expect to see in a CTF, how to tackle them, and what to look out for.

--- a/content/events/2024/11tba-ctf_thing.md
+++ b/content/events/2024/11tba-ctf_thing.md
@@ -6,6 +6,7 @@ end: 2024-11-01T00:00:01
 ---
 
 The details of this event have yet to be officially announced.
+<!--more-->
 
 What I can tell you, is that this is a CTF-related event that we're running in collaboration with DoCSoc, sometime in November. Please look forward to it ;)
 


### PR DESCRIPTION
Was trying to reduce summary size earlier, but couldn't figure out how, this should work